### PR TITLE
fix: update Flutter version, remove .PluginRegistry.Registrar

### DIFF
--- a/android/src/main/kotlin/carnegietechnologies/gallery_saver/GallerySaverPlugin.kt
+++ b/android/src/main/kotlin/carnegietechnologies/gallery_saver/GallerySaverPlugin.kt
@@ -9,7 +9,6 @@ import io.flutter.plugin.common.MethodCall
 import io.flutter.plugin.common.MethodChannel
 import io.flutter.plugin.common.MethodChannel.MethodCallHandler
 import io.flutter.plugin.common.MethodChannel.Result
-import io.flutter.plugin.common.PluginRegistry.Registrar
 
 class GallerySaverPlugin : FlutterPlugin, MethodCallHandler, ActivityAware {
 
@@ -57,3 +56,4 @@ class GallerySaverPlugin : FlutterPlugin, MethodCallHandler, ActivityAware {
 
     }
 }
+


### PR DESCRIPTION
PluginRegistry.Registrar being deprecated in Flutter, which occurs when migrating from older Flutter versions to the new Android embedding (v2)